### PR TITLE
feat: Add essay get API

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,5 +24,6 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': 'off',
   },
 };

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -27,6 +27,7 @@ import { TypeOrmOptions } from '../typeorm.options';
     AuthModule,
     EssayModule,
     MailModule,
+    RedisModule,
   ],
   providers: [
     { provide: APP_INTERCEPTOR, useClass: DeviceInterceptor },

--- a/src/common/interceptros/jwt.interceptor.ts
+++ b/src/common/interceptros/jwt.interceptor.ts
@@ -16,7 +16,7 @@ export class JwtInterceptor implements NestInterceptor {
     return next.handle().pipe(
       tap(() => {
         if (!response.headersSent && request.user) {
-          const newJwt = generateJWT(request.user.id, request.user.email, request.user.black);
+          const newJwt = generateJWT(request.user.id, request.user.email);
           response.setHeader('Authorization', `Bearer ${newJwt}`);
         }
       }),

--- a/src/common/interfaces/essay/findMyEssayQuery.interface.ts
+++ b/src/common/interfaces/essay/findMyEssayQuery.interface.ts
@@ -1,0 +1,6 @@
+export interface FindMyEssayQueryInterface {
+  author: object;
+  category: object;
+  linkedOut: boolean;
+  published?: boolean;
+}

--- a/src/common/pipes/optionalBool.pipe.ts
+++ b/src/common/pipes/optionalBool.pipe.ts
@@ -1,0 +1,15 @@
+import { PipeTransform, Injectable, ArgumentMetadata, BadRequestException } from '@nestjs/common';
+
+@Injectable()
+export class OptionalBoolPipe implements PipeTransform<string, boolean | undefined> {
+  transform(value: string | undefined, metadata: ArgumentMetadata): boolean | undefined {
+    if (value === '' || value === 'false') {
+      return false;
+    }
+    if (value === 'true') {
+      return true;
+    } else {
+      throw new BadRequestException(`Invalid boolean value for ${metadata.data}`);
+    }
+  }
+}

--- a/src/common/pipes/optionalParseInt.pipe.ts
+++ b/src/common/pipes/optionalParseInt.pipe.ts
@@ -1,0 +1,13 @@
+import { PipeTransform, Injectable, ArgumentMetadata, BadRequestException } from '@nestjs/common';
+
+@Injectable()
+export class OptionalParseIntPipe implements PipeTransform<string, number | undefined> {
+  transform(value: string, metadata: ArgumentMetadata): number | undefined {
+    if (value === '') return undefined;
+    const val = parseInt(value, 10);
+    if (isNaN(val)) {
+      throw new BadRequestException('Validation failed');
+    }
+    return val;
+  }
+}

--- a/src/common/pipes/pagingParseInt.pipe.ts
+++ b/src/common/pipes/pagingParseInt.pipe.ts
@@ -1,0 +1,15 @@
+import { PipeTransform, Injectable, ArgumentMetadata, BadRequestException } from '@nestjs/common';
+
+@Injectable()
+export class PagingParseIntPipe implements PipeTransform<string, number | undefined> {
+  constructor(private defaultValue: number) {}
+  transform(value: string, metadata: ArgumentMetadata): number | undefined {
+    if (value === '') return this.defaultValue;
+
+    const val = parseInt(value, 10);
+    if (isNaN(val)) {
+      throw new BadRequestException('Validation failed');
+    }
+    return val;
+  }
+}

--- a/src/common/types/express.d.ts
+++ b/src/common/types/express.d.ts
@@ -8,7 +8,7 @@ declare global {
       email: string;
       password?: string;
       gender?: string;
-      black?: boolean;
+      banned?: boolean;
       role?: string;
       oauthInfo?: object;
       birthDate?: Date;

--- a/src/common/utils/jwt.utils.ts
+++ b/src/common/utils/jwt.utils.ts
@@ -2,8 +2,8 @@ import * as jwt from 'jsonwebtoken';
 import * as dotenv from 'dotenv';
 dotenv.config();
 
-export const generateJWT = (id: number, email: string, black: boolean): string => {
+export const generateJWT = (id: number, email: string): string => {
   const secretKey = process.env.JWT_SECRET;
-  const options = { expiresIn: '30m' };
-  return jwt.sign({ id: id, email: email, black: black }, secretKey, options);
+  const options = { expiresIn: '1440m' }; // todo 귀찮아서 일단 길게해놓음
+  return jwt.sign({ id: id, email: email }, secretKey, options);
 };

--- a/src/entities/essay.entity.ts
+++ b/src/entities/essay.entity.ts
@@ -46,7 +46,7 @@ export class Essay {
 
   @Index()
   @Column({ default: false })
-  publish: boolean;
+  published: boolean;
 
   @Column({ default: false, name: 'linked_out' })
   linkedOut: boolean;

--- a/src/entities/reviewQueue.entity.ts
+++ b/src/entities/reviewQueue.entity.ts
@@ -15,7 +15,7 @@ export class ReviewQueue {
   id: number;
 
   @Column()
-  type: 'publish' | 'linked_out';
+  type: 'published' | 'linked_out';
 
   @JoinColumn({ name: 'essay_id' })
   @ManyToOne(() => Essay, (essay) => essay.review)

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -42,7 +42,7 @@ export class User {
   role: string;
 
   @Column({ default: false })
-  black: boolean;
+  banned: boolean;
 
   @Column({ name: 'subscription_end', type: 'timestamp', nullable: true })
   subscriptionEnd: Date;

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,8 +27,8 @@ async function bootstrap() {
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,
-      transform: true,
-      transformOptions: { enableImplicitConversion: true },
+      transform: false,
+      transformOptions: { enableImplicitConversion: false },
     }),
   );
   app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -38,7 +38,6 @@ export class AuthController {
   })
   @ApiBody({ type: CheckEmailReqDto })
   @ApiResponse({ status: 200, type: isBoolean })
-  @UsePipes(new ValidationPipe())
   async checkEmail(@Body() data: CheckEmailReqDto) {
     return await this.authService.checkEmail(data);
   }
@@ -50,7 +49,6 @@ export class AuthController {
   })
   @ApiBody({ type: CreateUserReqDto })
   @ApiResponse({ status: 201 })
-  @UsePipes(new ValidationPipe())
   async verify(@Body() createUserDto: CreateUserReqDto) {
     await this.authService.isEmailOwned(createUserDto);
 
@@ -83,7 +81,6 @@ export class AuthController {
   })
   @ApiBody({ type: LoginReqDto })
   @ApiResponse({ status: 200 })
-  @UsePipes(new ValidationPipe())
   @UseGuards(AuthGuard('local'))
   async login() {
     return;

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -12,7 +12,7 @@ import * as bcrypt from 'bcrypt';
 @Injectable()
 export class AuthService {
   constructor(
-    @InjectRedis() private readonly redis: Redis,
+    @InjectRedis() private readonly redis: Redis, // todo redisService 주입
     private readonly authRepository: AuthRepository,
     private readonly mailService: MailService,
   ) {}
@@ -88,6 +88,6 @@ export class AuthService {
   //       });
   //     }
   //   }
-  //   return generateJWT(existingUser.id, existingUser.email, existingUser.black);
+  //   return generateJWT(existingUser.id, existingUser.email, existingUser.banned);
   // }
 }

--- a/src/modules/auth/dto/createUserReq.dto.ts
+++ b/src/modules/auth/dto/createUserReq.dto.ts
@@ -7,22 +7,22 @@ export class CreateUserReqDto {
   @IsEmail()
   email: string;
 
-  @ApiProperty()
+  @ApiProperty({ required: false })
   @IsOptional()
   @IsString()
-  password?: string;
+  password: string;
 
-  @ApiProperty()
+  @ApiProperty({ required: false })
   @IsOptional()
   @IsDate()
   birthDate?: Date;
 
-  @ApiProperty()
+  @ApiProperty({ required: false })
   @IsOptional()
   @IsString()
   gender?: string;
 
-  @ApiProperty()
+  @ApiProperty({ required: false })
   @IsOptional()
   oauthInfo?: object;
 }

--- a/src/modules/auth/dto/userRes.dto.ts
+++ b/src/modules/auth/dto/userRes.dto.ts
@@ -21,7 +21,7 @@ export class UserResDto {
   password: string;
 
   @Exclude()
-  black: boolean;
+  banned: boolean;
 
   @Exclude()
   role: string;

--- a/src/modules/essay/dto/createEssay.dto.ts
+++ b/src/modules/essay/dto/createEssay.dto.ts
@@ -24,7 +24,7 @@ export class CreateEssayDto {
 
   @IsNotEmpty()
   @IsBoolean()
-  publish: boolean;
+  published: boolean;
 
   @IsNotEmpty()
   @IsBoolean()

--- a/src/modules/essay/dto/createEssayReq.dto.ts
+++ b/src/modules/essay/dto/createEssayReq.dto.ts
@@ -12,27 +12,27 @@ export class CreateEssayReqDto {
   @IsNotEmpty()
   content: string;
 
-  @ApiProperty()
+  @ApiProperty({ required: false })
   @IsNumber()
   @IsOptional()
   linkedOutGauge: number;
 
-  @ApiProperty()
+  @ApiProperty({ required: false })
   @IsNumber()
   @IsOptional()
   categoryId: number;
 
-  @ApiProperty()
+  @ApiProperty({ required: false })
   @IsString()
   @IsOptional()
   thumbnail: string;
 
-  @ApiProperty()
+  @ApiProperty({ required: false })
   @IsOptional()
   @IsBoolean()
-  publish: boolean;
+  published: boolean;
 
-  @ApiProperty()
+  @ApiProperty({ required: false })
   @IsOptional()
   @IsBoolean()
   linkedOut: boolean;

--- a/src/modules/essay/dto/essayListRes.dto.ts
+++ b/src/modules/essay/dto/essayListRes.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { EssayResDto } from './essayRes.dto';
+
+export class EssayListResDto {
+  @ApiProperty({ type: [EssayResDto] })
+  essays: EssayResDto[];
+
+  @ApiProperty()
+  total: number;
+
+  @ApiProperty()
+  totalPage: number;
+
+  @ApiProperty()
+  page: number;
+}

--- a/src/modules/essay/dto/essayRes.dto.ts
+++ b/src/modules/essay/dto/essayRes.dto.ts
@@ -1,17 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean, IsDate, IsNumber, IsString } from 'class-validator';
-import { Expose } from 'class-transformer';
+import { Exclude, Expose } from 'class-transformer';
 
 export class EssayResDto {
   @ApiProperty()
   @IsNumber()
   @Expose()
   id: number;
-
-  @ApiProperty()
-  @IsNumber()
-  @Expose()
-  authorId: number;
 
   @ApiProperty()
   @IsDate()
@@ -25,23 +20,18 @@ export class EssayResDto {
 
   @ApiProperty()
   @IsNumber()
-  @Expose()
+  @Exclude()
   views: number;
 
   @ApiProperty()
   @IsBoolean()
   @Expose()
-  publish: boolean;
+  published: boolean;
 
   @ApiProperty()
   @IsBoolean()
   @Expose()
   linkedOut: boolean;
-
-  @ApiProperty()
-  @IsNumber()
-  @Expose()
-  categoryId: number;
 
   @ApiProperty()
   @IsNumber()

--- a/src/modules/essay/dto/updateEssayReq.dto.ts
+++ b/src/modules/essay/dto/updateEssayReq.dto.ts
@@ -2,37 +2,37 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean, IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class UpdateEssayReqDto {
-  @ApiProperty()
+  @ApiProperty({ required: false })
   @IsString()
   @IsOptional()
   title: string;
 
-  @ApiProperty()
+  @ApiProperty({ required: false })
   @IsString()
   @IsOptional()
   content: string;
 
-  @ApiProperty()
+  @ApiProperty({ required: false })
   @IsNumber()
   @IsOptional()
   linkedOutGauge: number;
 
-  @ApiProperty()
+  @ApiProperty({ required: false })
   @IsNumber()
   @IsOptional()
   categoryId: number;
 
-  @ApiProperty()
+  @ApiProperty({ required: false })
   @IsString()
   @IsOptional()
   thumbnail: string;
 
-  @ApiProperty()
+  @ApiProperty({ required: false })
   @IsBoolean()
   @IsOptional()
-  publish: boolean;
+  published: boolean;
 
-  @ApiProperty()
+  @ApiProperty({ required: false })
   @IsBoolean()
   @IsOptional()
   linkedOut: boolean;

--- a/src/modules/essay/essay.module.ts
+++ b/src/modules/essay/essay.module.ts
@@ -7,6 +7,7 @@ import { EssayService } from './essay.service';
 import { AuthService } from '../auth/auth.service';
 import { MailService } from '../mail/mail.service';
 import { UserService } from '../user/user.service';
+import { RedisService } from '../redis/redis.service';
 import { EssayRepository } from './essay.repository';
 import { AuthRepository } from '../auth/auth.repository';
 import { UserRepository } from '../user/user.repository';
@@ -36,6 +37,7 @@ dotenv.config();
     EssayRepository,
     UserService,
     UserRepository,
+    RedisService,
     strategies.JwtStrategy,
   ],
 })

--- a/src/modules/essay/essay.service.ts
+++ b/src/modules/essay/essay.service.ts
@@ -1,15 +1,17 @@
 import { Injectable } from '@nestjs/common';
-import { InjectRedis } from '@nestjs-modules/ioredis';
-import { CreateEssayReqDto } from './dto/createEssayReq.dto';
+import { Transactional } from 'typeorm-transactional';
+import { plainToInstance } from 'class-transformer';
 import { EssayRepository } from './essay.repository';
 import { UserRepository } from '../user/user.repository';
-import Redis from 'ioredis';
-import { Transactional } from 'typeorm-transactional';
+import { CreateEssayReqDto } from './dto/createEssayReq.dto';
+import { EssayResDto } from './dto/essayRes.dto';
+import { FindMyEssayQueryInterface } from '../../common/interfaces/essay/findMyEssayQuery.interface';
+import { RedisService } from '../redis/redis.service';
 
 @Injectable()
 export class EssayService {
   constructor(
-    @InjectRedis() private readonly redis: Redis,
+    private readonly redisService: RedisService,
     private readonly essayRepository: EssayRepository,
     private readonly userRepository: UserRepository,
   ) {}
@@ -22,16 +24,16 @@ export class EssayService {
       device: device,
       author: user,
     };
-    if (requester.black) {
+    if (requester.banned) {
       const adjustedData = {
         ...essayData,
-        publish: false,
+        published: false,
         linkedOut: false,
       };
       const createdEssay = await this.essayRepository.createEssay(adjustedData);
 
       const essay = await this.essayRepository.findEssayById(createdEssay.id);
-      const reviewType = data.publish ? 'publish' : data.linkedOut ? 'linked_out' : null;
+      const reviewType = data.published ? 'published' : data.linkedOut ? 'linked_out' : null;
 
       if (reviewType) {
         await this.essayRepository.createReviewRequest(user, essay, reviewType);
@@ -40,28 +42,74 @@ export class EssayService {
       return createdEssay;
     }
 
-    return this.essayRepository.createEssay(essayData);
+    const createdEssay = await this.essayRepository.createEssay(essayData);
+
+    await this.redisService.deleteCachePattern('essays-*');
+
+    return plainToInstance(EssayResDto, createdEssay, {
+      strategy: 'exposeAll',
+      excludeExtraneousValues: true,
+    });
   }
 
   @Transactional()
-  async updateEssay(requester: Express.User, essayId: string, data: CreateEssayReqDto) {
+  async updateEssay(requester: Express.User, essayId: number, data: CreateEssayReqDto) {
     const user = await this.userRepository.findById(requester.id);
-    const essay = await this.essayRepository.findEssayById(parseInt(essayId, 10));
+    const essay = await this.essayRepository.findEssayById(essayId);
     if (!essay) throw new Error('Essay not found');
 
-    const isUnderReview = await this.essayRepository.findReviewByEssayId(parseInt(essayId, 10));
+    const isUnderReview = await this.essayRepository.findReviewByEssayId(essayId);
     if (isUnderReview) throw new Error('Update rejected: Essay is currently under review');
 
-    if (requester.black) {
-      if (data.publish || data.linkedOut) {
-        const reviewType = data.publish ? 'publish' : data.linkedOut ? 'linked_out' : null;
+    if (requester.banned) {
+      if (data.published || data.linkedOut) {
+        const reviewType = data.published ? 'published' : data.linkedOut ? 'linked_out' : null;
         await this.essayRepository.createReviewRequest(user, essay, reviewType);
         return { essay, message: 'Review request created due to policy violations.' };
       }
-      data.publish = false;
+      data.published = false;
       data.linkedOut = false;
     }
 
-    return await this.essayRepository.updateEssay(essay, data);
+    const updatedEssay = await this.essayRepository.updateEssay(essay, data);
+
+    await this.redisService.deleteCachePattern('essays-*');
+
+    return plainToInstance(EssayResDto, updatedEssay, {
+      strategy: 'exposeAll',
+      excludeExtraneousValues: true,
+    });
+  }
+
+  async getMyEssay(
+    userId: number,
+    published: boolean,
+    categoryId: number,
+    page: number,
+    limit: number,
+  ) {
+    const cacheKey = `essays-${userId}-${published}-${categoryId}-${page}-${limit}`;
+    const cachedData = await this.redisService.getCached(cacheKey);
+    if (cachedData) {
+      return JSON.parse(cachedData);
+    }
+
+    const query: FindMyEssayQueryInterface = {
+      author: { id: userId },
+      category: { id: categoryId },
+      linkedOut: false,
+    };
+    if (published === true) query.published = true;
+
+    const { essays, total } = await this.essayRepository.findMyEssay(query, page, limit);
+    const totalPage: number = Math.ceil(total / limit);
+    const essayDtos = plainToInstance(EssayResDto, essays, {
+      strategy: 'exposeAll',
+      excludeExtraneousValues: true,
+    });
+
+    const result = { essays: essayDtos, total, totalPage, page };
+    await this.redisService.setCached(cacheKey, result, 900);
+    return result;
   }
 }

--- a/src/modules/redis/redis.module.ts
+++ b/src/modules/redis/redis.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { RedisService } from './redis.service';
+
+@Module({
+  imports: [],
+  providers: [RedisService],
+  exports: [RedisService],
+})
+export class MailModule {}

--- a/src/modules/redis/redis.service.ts
+++ b/src/modules/redis/redis.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@nestjs/common';
+import Redis from 'ioredis';
+import { InjectRedis } from '@nestjs-modules/ioredis';
+
+@Injectable()
+export class RedisService {
+  @InjectRedis() private readonly redis: Redis;
+
+  async getCached(key: string): Promise<any> {
+    const data = await this.redis.get(key);
+    return data ? JSON.parse(data) : null;
+  }
+
+  async setCached(key: string, data: any, ttl: number): Promise<void> {
+    await this.redis.set(key, JSON.stringify(data), 'EX', ttl);
+  }
+
+  async deleteCachePattern(pattern: string): Promise<void> {
+    const stream = this.redis.scanStream({
+      match: pattern,
+      count: 100,
+    });
+
+    let pipeline = this.redis.pipeline();
+    let keysDeleted = 0;
+
+    for await (const keys of stream) {
+      if (keys.length) {
+        pipeline.del(...keys);
+        keysDeleted += keys.length;
+
+        if (pipeline.length >= 1000) {
+          await pipeline.exec(); // 1000개 명령마다
+          pipeline = this.redis.pipeline(); // 파이프라인 재설정
+        }
+      }
+    }
+
+    if (pipeline.length) {
+      await pipeline.exec(); // 나머지 명령 실행
+    }
+
+    // todo 나중에 지우기
+    console.log(`Deleted ${keysDeleted} keys matching pattern ${pattern}`);
+  }
+}


### PR DESCRIPTION
- 레디스 모듈, 서비스 추가: 기존에 각 모듈 리포지토리 레이어에 바로 주입해서 사용하던 방식에서 분리 후 의존성 주입방식으로 변경. 에세이 조회시 캐싱, 에세이 작성 및 업데이트시 캐싱 데이터 삭제.
- 파이프데코레이터: 전역으로 처리되고 있던 검증파이프를 컨트롤러에서 제거
- 경로매개변수, 쿼리매개변수 자동 형변환을 위한 파이프 추가
- swagger api: 이제 api-doc에서 쿼리와 바디의 필드 중 필수여부를 확인 가능
- 다수의 dto 필드명 수정

## PR Type

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [x] 코드 스타일 변경(Code style update) (formatting, local variables)
- [x] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [x] 문서 내용 변경
- [ ] Other… Please describe:

<br />

## Summary

<br />

## Describe your changes

<br />

## Issue Number or Link