### PR TITLE
fix: update jwtAuthGuard redis key expiration time

### DIFF
--- a/src/common/guards/jwtAuth.guard.ts
+++ b/src/common/guards/jwtAuth.guard.ts
@@ -75,7 +75,7 @@ export class JwtAuthGuard extends AuthGuard('jwt') implements CanActivate {
       return this.handleTokenExpired(request, response);
     }
 
-    await this.redis.set(inProgressKey, 'true', 'EX', 0.5);
+    await this.redis.set(inProgressKey, 'true', 'PX', 300);
 
     /** @description 리프레쉬 토큰 사용 후 5초간 만료토큰 허용 */
     const recentlyRefreshedToken = await this.redis.get(recentTokenKey);


### PR DESCRIPTION
## PR Type

- [x] 버그수정
- [ ] 기능개발
- [ ] 코드 스타일 변경
- [ ] 리팩토링
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

<br />

## Summary

<br />

## Describe your changes
Redis `EX` 옵션에 0.5초의 소수 값을 사용하여 "ERR value is not an integer or out of range" 에러가 발생하는 문제를 수정했습니다. `EX` 옵션은 정수 값을 요구하므로, 이를 밀리초 단위로 설정할 수 있는 `PX` 옵션을 사용하여 0.5초를 500ms로 정확하게 반영했습니다.


<br />

## Issue Number or Link